### PR TITLE
Lazyload: Replace data-height/data-width with height/width attributes

### DIFF
--- a/modules/dcf_lazyload/dcf_lazyload.module
+++ b/modules/dcf_lazyload/dcf_lazyload.module
@@ -57,8 +57,8 @@ function dcf_lazyload_preprocess_responsive_image(&$variables) {
       unset($variables['img_element']['#attributes']['data-sizes']);
     }
 
-    $variables['img_element']['#attributes']['data-width'] = $variables['width'];
-    $variables['img_element']['#attributes']['data-height'] = $variables['height'];
+    $variables['img_element']['#attributes']['width'] = $variables['width'];
+    $variables['img_element']['#attributes']['height'] = $variables['height'];
 
     // #suffix is run through Xss::filterAdmin(), so a post-render function
     // must be used instead to add <noscript>.

--- a/modules/dcf_lazyload/src/DcfLazyloadPostrender.php
+++ b/modules/dcf_lazyload/src/DcfLazyloadPostrender.php
@@ -57,8 +57,8 @@ class DcfLazyloadPostrender implements TrustedCallbackInterface {
     $no_script_attributes['class'] = array_diff($no_script_attributes['class']->value(), $class_remove);
 
     // Set wrapper classes.
-    $height = $element['#attributes']['data-height'];
-    $width = $element['#attributes']['data-width'];
+    $height = $element['#attributes']['height'];
+    $width = $element['#attributes']['width'];
     $ratio = round($width / $height, 2);
 
     $wrapper_attributes = new Attribute();
@@ -95,10 +95,6 @@ class DcfLazyloadPostrender implements TrustedCallbackInterface {
         $style_string = '<style>.' . $class . '::before { padding-top: ' . $percentage . '%!important; }</style>';
         $wrapper_attributes['class'][] = $class;
     }
-
-    // Remove data-height and data-width attributes prior to printing.
-    unset($element['#attributes']['data-height']);
-    unset($element['#attributes']['data-width']);
 
     return $style_string . '<div' . $wrapper_attributes . '>' . $markup . '<noscript><img' . $no_script_attributes . '></noscript></div>';
   }

--- a/modules/dcf_lazyload/tests/src/Functional/DcfLazyLoadTest.php
+++ b/modules/dcf_lazyload/tests/src/Functional/DcfLazyLoadTest.php
@@ -113,6 +113,9 @@ class DcfLazyLoadTest extends ImageFieldTestBase {
     $this->assertNoRaw('<noscript>');
     $this->assertNoRaw('dcf-ratio');
     $this->assertNoRaw('dcf-ratio-1x1');
+    // Verify height and width attributes are not set.
+    $this->assertNoRaw('height="640"');
+    $this->assertNoRaw('width="640"');
 
     // Verify JS and CSS are not loaded.
     $this->assertNoRaw('dcf_lazyload/js/bundle.js');
@@ -138,6 +141,9 @@ class DcfLazyLoadTest extends ImageFieldTestBase {
     $this->assertRaw('dcf-ratio');
     // Verify ratio class is added to wrapper.
     $this->assertRaw('dcf-ratio-1x1');
+    // Verify height and width attributes are set.
+    $this->assertRaw('height="640"');
+    $this->assertRaw('width="640"');
 
     // Verify JS and CSS are loaded.
     $this->assertRaw('dcf_lazyload/js/bundle.js');
@@ -285,6 +291,9 @@ class DcfLazyLoadTest extends ImageFieldTestBase {
     $this->assertNoRaw('<noscript>');
     $this->assertNoRaw('dcf-ratio');
     $this->assertNoRaw('dcf-ratio-1x1');
+    // Verify height and width attributes are set.
+    $this->assertNoRaw('height="640"');
+    $this->assertNoRaw('width="640"');
 
     // Verify JS and CSS are not loaded.
     $this->assertNoRaw('dcf_lazyload/js/bundle.js');
@@ -303,6 +312,9 @@ class DcfLazyLoadTest extends ImageFieldTestBase {
     $this->assertRaw('dcf-ratio');
     // Verify ratio class is added to wrapper.
     $this->assertRaw('dcf-ratio-1x1');
+    // Verify height and width attributes are set.
+    $this->assertRaw('height="640"');
+    $this->assertRaw('width="640"');
 
     // Verify JS and CSS are loaded.
     $this->assertRaw('dcf_lazyload/js/bundle.js');


### PR DESCRIPTION
This PR seeks to update the markup generated by the dcf_lazyload module to remove the `data-height` and `data-width` attributes and to replace them with `height` and `width` attributes. This change conforms with the current DCF JS expectations.