### PR TITLE
Lazyload: Remove auto sizes functionality

### DIFF
--- a/modules/dcf_lazyload/config/schema/dcf_lazyload.schema.yml
+++ b/modules/dcf_lazyload/config/schema/dcf_lazyload.schema.yml
@@ -5,9 +5,6 @@ dcf_lazyload_base:
     dcf_lazyload_enable:
       type: boolean
       label: 'DCF Lazy Load enabled'
-    dcf_lazyload_sizes:
-      type: boolean
-      label: 'DCF Lazy Loading auto-calculate sizes enabled'
 
 field.formatter.third_party.dcf_lazyload:
   type: dcf_lazyload_base
@@ -30,9 +27,6 @@ field.formatter.settings.responsive_image:
     dcf_lazyload_enable:
       type: boolean
       label: 'DCF Lazy Load enabled'
-    dcf_lazyload_sizes:
-      type: boolean
-      label: 'DCF Lazy Loading auto-calculate sizes enabled'
 
 dcf_lazyload.settings:
   type: config_object

--- a/modules/dcf_lazyload/dcf_lazyload.field_formatter.inc
+++ b/modules/dcf_lazyload/dcf_lazyload.field_formatter.inc
@@ -19,17 +19,6 @@ function dcf_lazyload_field_formatter_third_party_settings_form($plugin, $field_
       '#default_value' => $plugin->getThirdPartySetting('dcf_lazyload', 'dcf_lazyload_enable'),
       '#value_callback' => '_dcf_lazyload_checkbox_boolean',
     ];
-    $element['dcf_lazyload_sizes'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Automatically calculate "sizes" attribute'),
-      '#default_value' => $plugin->getThirdPartySetting('dcf_lazyload', 'dcf_lazyload_sizes'),
-      '#value_callback' => '_dcf_lazyload_checkbox_boolean',
-      '#states' => [
-        'visible' => [
-          ':input[name="fields[field_image][settings_edit_form][third_party_settings][dcf_lazyload][dcf_lazyload_enable]"]' => ['checked' => TRUE],
-        ],
-      ],
-    ];
     return $element;
   }
 }
@@ -41,9 +30,6 @@ function dcf_lazyload_field_formatter_settings_summary_alter(&$summary, $context
   if ($context['formatter']->getPluginId() == 'responsive_image') {
     if ($context['formatter']->getThirdPartySetting('dcf_lazyload', 'dcf_lazyload_enable')) {
       $summary[] = t('DCF lazy loading is enabled.');
-    }
-    if ($context['formatter']->getThirdPartySetting('dcf_lazyload', 'dcf_lazyload_sizes')) {
-      $summary[] = t('"Sizes" attribute is auto-calculated');
     }
   }
 }
@@ -71,12 +57,6 @@ function dcf_lazyload_preprocess_field(&$variables) {
       ) {
       foreach ($variables['items'] as $key => $item) {
         $variables['items'][$key]['content']['#item']->__set('dcf_lazyload_enable', TRUE);
-
-        if (isset($field_display['third_party_settings']['dcf_lazyload']['dcf_lazyload_sizes'])
-          && $field_display['third_party_settings']['dcf_lazyload']['dcf_lazyload_sizes'] == TRUE
-          ) {
-          $variables['items'][$key]['content']['#item']->__set('dcf_lazyload_sizes', TRUE);
-        }
       }
     }
   }

--- a/modules/dcf_lazyload/dcf_lazyload.post_update.php
+++ b/modules/dcf_lazyload/dcf_lazyload.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * This module provides post_update functions.
+ */
+
+/**
+ * Lazyload schema update.
+ */
+function dcf_lazyload_post_update_lazyload_schema() {
+  // Clear cache.
+}

--- a/modules/dcf_lazyload/dcf_lazyload.views_field.inc
+++ b/modules/dcf_lazyload/dcf_lazyload.views_field.inc
@@ -56,18 +56,6 @@ function dcf_lazyload_form_views_ui_config_item_form_alter(&$form, FormStateInte
       '#value_callback' => '_dcf_lazyload_checkbox_boolean',
       '#weight' => -9,
     ];
-    $form['options']['settings']['dcf_lazyload_sizes'] = [
-      '#type' => 'checkbox',
-      '#title' => t('Automatically calculate "sizes" attribute'),
-      '#default_value' => (isset($settings['dcf_lazyload_sizes'])) ? $settings['dcf_lazyload_sizes'] : FALSE,
-      '#value_callback' => '_dcf_lazyload_checkbox_boolean',
-      '#weight' => -8,
-      '#states' => [
-        'visible' => [
-          ':input[name="options[settings][dcf_lazyload_enable]"]' => ['checked' => TRUE],
-        ],
-      ],
-    ];
   }
 }
 
@@ -91,7 +79,6 @@ function dcf_lazyload_preprocess_views_view_field(&$variables) {
           // Loop through field value (fields can be multi-value).
           foreach ($field_value as $key => $item) {
             $field_value[$key]['dcf_lazyload_enable'] = (isset($settings['dcf_lazyload_enable'])) ? $settings['dcf_lazyload_enable'] : FALSE;
-            $field_value[$key]['dcf_lazyload_sizes'] = (isset($settings['dcf_lazyload_sizes'])) ? $settings['dcf_lazyload_sizes'] : FALSE;
           }
           // Overwrite field value array with updated value.
           // Attributes will be added by

--- a/modules/dcf_lazyload/tests/modules/dcf_lazyload_test/config/optional/views.view.dcf_lazyload_test_view.yml
+++ b/modules/dcf_lazyload/tests/modules/dcf_lazyload_test/config/optional/views.view.dcf_lazyload_test_view.yml
@@ -174,7 +174,6 @@ display:
             responsive_image_style: test_responsive_image_style
             image_link: ''
             dcf_lazyload_enable: false
-            dcf_lazyload_sizes: false
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -373,7 +372,6 @@ display:
             responsive_image_style: test_responsive_image_style
             image_link: ''
             dcf_lazyload_enable: false
-            dcf_lazyload_sizes: false
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -508,142 +506,6 @@ display:
             responsive_image_style: test_responsive_image_style
             image_link: ''
             dcf_lazyload_enable: true
-            dcf_lazyload_sizes: false
-          group_column: ''
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-      defaults:
-        fields: false
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url.query_args
-        - 'user.node_grants:view'
-        - user.permissions
-      tags:
-        - 'config:field.storage.node.field_image'
-  page_3:
-    display_plugin: page
-    id: page_3
-    display_title: 'Lazy loading enabled + auto sizes'
-    position: 3
-    display_options:
-      display_extenders: {  }
-      display_description: ''
-      path: dcf-lazyload-test-view-enabled-sizes
-      fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        field_image:
-          id: field_image
-          table: node__field_image
-          field: field_image
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: responsive_image
-          settings:
-            responsive_image_style: test_responsive_image_style
-            image_link: ''
-            dcf_lazyload_enable: true
-            dcf_lazyload_sizes: true
           group_column: ''
           group_columns: {  }
           group_rows: true

--- a/modules/dcf_lazyload/tests/src/Functional/DcfLazyLoadTest.php
+++ b/modules/dcf_lazyload/tests/src/Functional/DcfLazyLoadTest.php
@@ -149,23 +149,6 @@ class DcfLazyLoadTest extends ImageFieldTestBase {
     $this->assertRaw('dcf_lazyload/js/bundle.js');
     $this->assertRaw('dcf_lazyload/css/dcf-lazyload.css');
 
-    // Verify dcf_lazyload_sizes is disabled.
-    $this->assertNoRaw('sizes="auto"');
-
-    // Update display options to enable sizes auto-calculation.
-    $display_options['third_party_settings'] = [
-      'dcf_lazyload' => [
-        'dcf_lazyload_enable' => TRUE,
-        'dcf_lazyload_sizes' => TRUE,
-      ],
-    ];
-    $display->setComponent($this->imageFieldName, $display_options)->save();
-
-    $this->drupalGet('node/' . $nid);
-
-    // Verify dcf_lazyload_sizes is enabled.
-    $this->assertRaw('sizes="auto"');
-
     // Upload an image with a 4x3 ratio.
     $module_path = drupal_get_path('module', 'dcf_lazyload');
     $test_image = new \stdClass();
@@ -319,15 +302,6 @@ class DcfLazyLoadTest extends ImageFieldTestBase {
     // Verify JS and CSS are loaded.
     $this->assertRaw('dcf_lazyload/js/bundle.js');
     $this->assertRaw('dcf_lazyload/css/dcf-lazyload.css');
-
-    // Verify dcf_lazyload_sizes is disabled.
-    $this->assertNoRaw('sizes="auto"');
-
-    // Load view with DCF lazyloading enabled with sizes autocalculated.
-    $this->drupalGet('dcf-lazyload-test-view-enabled-sizes');
-
-    // Verify dcf_lazyload_sizes is enabled.
-    $this->assertRaw('sizes="auto"');
   }
 
   /**


### PR DESCRIPTION
The current version of DCF lazy load doesn't check if the `sizes` attribute value is auto. It always overrides the `sizes` attribute value.

The PR seeks to remove the configuration options relating to this feature.